### PR TITLE
Restrict package to Elm 0.19.x

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,7 +8,7 @@
         "Optics.Core",
         "Optics.Basic"
     ],
-    "elm-version": "0.19.1 <= v <= 1.0.0",
+    "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/browser": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.5 <= v < 2.0.0",


### PR DESCRIPTION
It's likely that 0.20.x will introduce breaking changes and there's no guarantee that this package will work with future versions.